### PR TITLE
feat: add achievement-rate subcommand to display rule success rates

### DIFF
--- a/.claude/commands/issue-dev.md
+++ b/.claude/commands/issue-dev.md
@@ -1,0 +1,24 @@
+---
+allowed_tools: Bash(git:*), Bash(gh:*), Bash(task:*), Read(*.md), Read(*.py), Read(*.toml), Fetch(*)
+description: "引数で指定したissueの内容に従って開発を行う"
+---
+
+あなたは経験豊かなソフトウェアエンジニアです。
+あなたは、引数で指定したissueの内容に従って開発を行います。
+あなたは、以下のコマンドを使用して開発を行います。
+
+## 使用する主なコマンド
+
+- git: gitの操作を行う
+- gh: GitHubの操作を行う
+- task: taskの操作を行う
+
+## 開発の流れ
+
+1. 引数で指定したissueの内容をgh issue view {issue_number}で読み込む
+2. issueの内容にしたがって、mainブランチから新しいブランチを作成する。このとき、ブランチ名は `feature/{issue_number}_{開発する内容の概要を英語で}`
+3. 新しいブランチで開発を行う
+4. 開発が終わったら、task checkを実行して、エラーがないか確認する。エラーがあればエラーがなくなるまで修正する
+5. task checkで問題がなくなったらコミットして、pushする
+6. gh pr コマンドを使ってPull Requestを作成する。Pull Requestは日本語で作成してください。
+7. CIがパスするのを確認して、パスしていなかったら問題を修正する

--- a/src/pytestee/adapters/cli/handlers/achievement_rate_handler.py
+++ b/src/pytestee/adapters/cli/handlers/achievement_rate_handler.py
@@ -1,0 +1,75 @@
+"""Achievement rate command handler."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pytestee.adapters.cli.handlers.base_handler import BaseCommandHandler
+from pytestee.adapters.cli.services.output_service import OutputService
+from pytestee.adapters.presenters.achievement_rate_presenter import (
+    AchievementRatePresenter,
+)
+from pytestee.domain.rules.rule_validator import RuleConflictError
+from pytestee.usecases.calculate_achievement_rate import CalculateAchievementRateUseCase
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytestee.domain.models import AchievementRateResult
+
+
+class AchievementRateCommandHandler(BaseCommandHandler):
+    """Handler for the achievement rate command."""
+
+    def execute(
+        self,
+        target: Path,
+        output_format: str,
+        quiet: bool,
+        config_overrides: dict[str, Any] | None = None,
+    ) -> AchievementRateResult:
+        """Execute the achievement rate command.
+
+        Args:
+            target: Path to analyze
+            output_format: Output format (console/json)
+            quiet: Quiet mode flag
+            config_overrides: Configuration overrides
+
+        Returns:
+            Achievement rate result
+
+        Raises:
+            RuleConflictError: If rule conflicts are detected
+
+        """
+        if config_overrides is None:
+            config_overrides = {}
+
+        # Handle potential rule conflicts during registry creation
+        try:
+            registry = self.registry
+        except RuleConflictError as e:
+            raise RuleConflictError(
+                f"Configuration Error: {e}\\n"
+                "Use 'pytestee show-config' to review your configuration."
+            ) from e
+
+        # Initialize the use case
+        calculate_use_case = CalculateAchievementRateUseCase(
+            test_repository=self.repository,
+            checker_registry=registry,
+            config_manager=self.config_manager,
+        )
+
+        # Execute calculation
+        result = calculate_use_case.execute(target, config_overrides)
+
+        # Present results
+        if output_format == "console":
+            presenter = AchievementRatePresenter(quiet=quiet)
+            presenter.present(result)
+        elif output_format == "json":
+            OutputService.present_achievement_rate_json(result)
+
+        return result

--- a/src/pytestee/adapters/cli/services/output_service.py
+++ b/src/pytestee/adapters/cli/services/output_service.py
@@ -7,7 +7,12 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from pytestee.domain.models import AnalysisResult, CheckFailure, CheckSuccess
+from pytestee.domain.models import (
+    AchievementRateResult,
+    AnalysisResult,
+    CheckFailure,
+    CheckSuccess,
+)
 from pytestee.domain.rules.rule_validator import RuleConflictError, RuleValidator
 from pytestee.infrastructure.config.settings import ConfigManager
 from pytestee.registry import CheckerRegistry
@@ -42,6 +47,29 @@ class OutputService:
                     "function": check_result.function_name,
                 }
                 for check_result in result.check_results
+            ],
+        }
+        console.print(json.dumps(json_result, indent=2))
+
+    @staticmethod
+    def present_achievement_rate_json(result: AchievementRateResult) -> None:
+        """Present achievement rate results in JSON format."""
+        json_result = {
+            "summary": {
+                "total_files": result.total_files,
+                "total_tests": result.total_tests,
+                "overall_rate": result.overall_rate,
+            },
+            "rule_rates": [
+                {
+                    "rule_id": rule_rate.rule_id,
+                    "checker_name": rule_rate.checker_name,
+                    "total_checks": rule_rate.total_checks,
+                    "passed_checks": rule_rate.passed_checks,
+                    "failed_checks": rule_rate.failed_checks,
+                    "achievement_rate": rule_rate.achievement_rate,
+                }
+                for rule_rate in result.rule_rates
             ],
         }
         console.print(json.dumps(json_result, indent=2))

--- a/src/pytestee/adapters/presenters/achievement_rate_presenter.py
+++ b/src/pytestee/adapters/presenters/achievement_rate_presenter.py
@@ -1,0 +1,115 @@
+"""Achievement rate presenter for displaying results."""
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from pytestee.domain.models import AchievementRateResult
+
+
+class AchievementRatePresenter:
+    """Presenter for achievement rate results using Rich."""
+
+    def __init__(self, quiet: bool = False) -> None:
+        """Initialize the presenter.
+
+        Args:
+            quiet: Quiet mode flag
+
+        """
+        self.console = Console()
+        self.quiet = quiet
+
+    def present(self, result: AchievementRateResult) -> None:
+        """Present the achievement rate results to console.
+
+        Args:
+            result: Achievement rate result to display
+
+        """
+        if not self.quiet:
+            self._show_header()
+            self._show_summary(result)
+
+        self._show_rule_rates(result)
+
+        if not self.quiet:
+            self._show_footer(result)
+
+    def _show_header(self) -> None:
+        """Show header information."""
+        header = Panel(
+            "[bold blue]pytestee[/bold blue] - Achievement Rate Report",
+            style="blue",
+        )
+        self.console.print(header)
+        self.console.print()
+
+    def _show_summary(self, result: AchievementRateResult) -> None:
+        """Show summary statistics.
+
+        Args:
+            result: Achievement rate result
+
+        """
+        table = Table(title="Summary", show_header=False)
+        table.add_column("Metric", style="cyan")
+        table.add_column("Value", justify="right", style="white")
+
+        table.add_row("Test Files", str(result.total_files))
+        table.add_row("Test Functions", str(result.total_tests))
+        table.add_row("Overall Achievement Rate", f"{result.overall_rate:.1f}%")
+
+        self.console.print(table)
+        self.console.print()
+
+    def _show_rule_rates(self, result: AchievementRateResult) -> None:
+        """Show achievement rates for each rule.
+
+        Args:
+            result: Achievement rate result
+
+        """
+        table = Table(title="Rule Achievement Rates")
+        table.add_column("Rule ID", style="cyan", width=12)
+        table.add_column("Checker", style="dim", width=20)
+        table.add_column("Passed", justify="right", style="green", width=8)
+        table.add_column("Failed", justify="right", style="red", width=8)
+        table.add_column("Total", justify="right", style="white", width=8)
+        table.add_column("Rate", justify="right", style="bold", width=10)
+
+        for rule_rate in result.rule_rates:
+            # Color code the achievement rate
+            rate_str = f"{rule_rate.achievement_rate:.1f}%"
+            if rule_rate.achievement_rate >= 90:
+                rate_color = "green"
+            elif rule_rate.achievement_rate >= 70:
+                rate_color = "yellow"
+            else:
+                rate_color = "red"
+
+            table.add_row(
+                rule_rate.rule_id,
+                rule_rate.checker_name,
+                str(rule_rate.passed_checks),
+                str(rule_rate.failed_checks),
+                str(rule_rate.total_checks),
+                f"[{rate_color}]{rate_str}[/{rate_color}]",
+            )
+
+        self.console.print(table)
+        self.console.print()
+
+    def _show_footer(self, result: AchievementRateResult) -> None:
+        """Show footer with interpretation guide.
+
+        Args:
+            result: Achievement rate result
+
+        """
+        footer_text = """
+[dim]Rate Guide:[/dim]
+[green]≥90%[/green] Excellent  [yellow]70-89%[/yellow] Good  [red]<70%[/red] Needs Improvement
+"""
+        footer = Panel(footer_text.strip(), style="dim")
+        self.console.print(footer)

--- a/src/pytestee/domain/models.py
+++ b/src/pytestee/domain/models.py
@@ -289,3 +289,57 @@ class CheckerConfig:
         # 設定がNoneの場合は空の辞書で初期化
         if self.config is None:
             self.config = {}
+
+
+@dataclass
+class RuleAchievementRate:
+    """個別ルールの達成率。
+
+    各ルールごとの達成率(成功率)とその詳細情報を保持します。
+
+    Attributes:
+        rule_id: ルールID(例: PTAS001)
+        checker_name: チェッカー名
+        total_checks: 総チェック数
+        passed_checks: 成功したチェック数
+        failed_checks: 失敗したチェック数
+
+    """
+
+    rule_id: str
+    checker_name: str
+    total_checks: int
+    passed_checks: int
+    failed_checks: int
+
+    @property
+    def achievement_rate(self) -> float:
+        """達成率をパーセンテージで計算します。
+
+        Returns:
+            達成率(0.0-100.0の範囲)
+
+        """
+        if self.total_checks == 0:
+            return 100.0
+        return (self.passed_checks / self.total_checks) * 100.0
+
+
+@dataclass
+class AchievementRateResult:
+    """全体の達成率結果。
+
+    全ルールの達成率と統計情報を集約したものです。
+
+    Attributes:
+        total_files: 解析したファイル数
+        total_tests: 発見したテスト関数の総数
+        rule_rates: 各ルールの達成率リスト
+        overall_rate: 全体の達成率
+
+    """
+
+    total_files: int
+    total_tests: int
+    rule_rates: list[RuleAchievementRate]
+    overall_rate: float

--- a/src/pytestee/usecases/calculate_achievement_rate.py
+++ b/src/pytestee/usecases/calculate_achievement_rate.py
@@ -1,0 +1,116 @@
+"""Calculate achievement rate use case."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pytestee.domain.models import (
+    AchievementRateResult,
+    CheckSuccess,
+    RuleAchievementRate,
+)
+from pytestee.usecases.analyze_tests import AnalyzeTestsUseCase
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytestee.domain.interfaces import (
+        ICheckerRegistry,
+        IConfigManager,
+        ITestRepository,
+    )
+
+
+class CalculateAchievementRateUseCase:
+    """Calculate achievement rate for each rule."""
+
+    def __init__(
+        self,
+        test_repository: ITestRepository,
+        checker_registry: ICheckerRegistry,
+        config_manager: IConfigManager,
+    ) -> None:
+        """Initialize the use case.
+
+        Args:
+            test_repository: Test repository for file access
+            checker_registry: Registry for rule checkers
+            config_manager: Configuration manager
+
+        """
+        self._test_repository = test_repository
+        self._checker_registry = checker_registry
+        self._config_manager = config_manager
+
+    def execute(
+        self,
+        target: Path,
+        config_overrides: dict[str, Any] | None = None,
+    ) -> AchievementRateResult:
+        """Execute achievement rate calculation.
+
+        Args:
+            target: Path to analyze
+            config_overrides: Configuration overrides
+
+        Returns:
+            Achievement rate result
+
+        """
+        if config_overrides is None:
+            config_overrides = {}
+
+        # First, run the regular analysis to get all check results
+        analyze_use_case = AnalyzeTestsUseCase(
+            test_repository=self._test_repository,
+            checker_registry=self._checker_registry,
+            config_manager=self._config_manager,
+        )
+
+        analysis_result = analyze_use_case.execute(target, config_overrides)
+
+        # Group results by rule ID
+        rule_results: dict[str, dict[str, Any]] = {}
+
+        for result in analysis_result.check_results:
+            rule_id = result.rule_id
+            if rule_id not in rule_results:
+                rule_results[rule_id] = {
+                    "total": 0,
+                    "passed": 0,
+                    "failed": 0,
+                    "checker_name": result.checker_name,
+                }
+
+            rule_results[rule_id]["total"] += 1
+
+            # Check if this is a success or failure
+            if isinstance(result, CheckSuccess):
+                rule_results[rule_id]["passed"] += 1
+            else:
+                rule_results[rule_id]["failed"] += 1
+
+        # Create RuleAchievementRate objects
+        rule_rates = []
+        for rule_id, stats in rule_results.items():
+            rule_rate = RuleAchievementRate(
+                rule_id=rule_id,
+                checker_name=str(stats["checker_name"]),
+                total_checks=int(stats["total"]),
+                passed_checks=int(stats["passed"]),
+                failed_checks=int(stats["failed"]),
+            )
+            rule_rates.append(rule_rate)
+
+        # Sort by rule ID for consistent output
+        rule_rates.sort(key=lambda x: x.rule_id)
+
+        # Calculate overall achievement rate
+        overall_rate = analysis_result.success_rate
+
+        return AchievementRateResult(
+            total_files=analysis_result.total_files,
+            total_tests=analysis_result.total_tests,
+            rule_rates=rule_rates,
+            overall_rate=overall_rate,
+        )


### PR DESCRIPTION
## Summary
- Adds new `achievement-rate` CLI subcommand that displays the percentage of tests passing each quality rule
- Helps track progress when improving test quality by showing current compliance rates per rule
- Supports both console (with color-coded rate indicators) and JSON output formats

## Implementation Details
- **New Models**: `AchievementRateResult` and `RuleAchievementRate` for structured rate data
- **Use Case**: `CalculateAchievementRateUseCase` reuses existing analysis logic and calculates per-rule rates
- **Presenter**: `AchievementRatePresenter` with color-coded output (green ≥90%, yellow 70-89%, red <70%)
- **CLI Command**: `pytestee achievement-rate [target] [--format console|json] [--quiet]`
- **JSON Support**: Added `present_achievement_rate_json` method to OutputService

## Usage Examples
```bash
# Show achievement rates for current directory
pytestee achievement-rate

# Show rates in JSON format
pytestee achievement-rate --format json

# Show rates for specific directory, quiet mode
pytestee achievement-rate tests/ --quiet
```

## Test Plan
- [x] Implement the feature with proper architecture (Clean Architecture compliance)
- [x] All existing tests pass
- [x] Code passes linting, formatting, and type checking
- [x] Manual testing of console and JSON output formats
- [ ] Add unit tests for new components (can be done in follow-up)

Closes #29